### PR TITLE
Sequence blocking operations on a background thread.

### DIFF
--- a/DrawBot/app/src/main/java/com/deeplocal/drawbot/MainActivity.java
+++ b/DrawBot/app/src/main/java/com/deeplocal/drawbot/MainActivity.java
@@ -513,7 +513,6 @@ public class MainActivity extends Activity implements ImageReader.OnImageAvailab
 
         // get drawing lines
         ArrayList<Line> copicLines = LineAlgorithm.getCopicLines(faceMat);
-//        Utilities.printLineList("--- START COPIC LINES ---", copicLines, "--- END COPIC LINES ---");
 
         // add lines to move from center to starting point
         // (position at center facing top of page, turn left, move to edge, turn right, move to top, turn right, start drawing)
@@ -554,17 +553,20 @@ public class MainActivity extends Activity implements ImageReader.OnImageAvailab
     }
 
     private void startDrawing() {
+
         mState = State.DRAWING;
-        //TODO: Convert line queue into operations set on BG thread
+
         // start drawing in 3 secs
         Log.d(TAG, "Drawing in 3 secs..");
         mPhysicalInterface.holdLED(Color.MAGENTA, 3000);
+
         // begin drawing
         Log.d(TAG, "Begin drawing");
         mPhysicalInterface.writeLED(Color.BLUE);
 
         // Queue up all the drawing ops
         for (int i = 0; i < mDrawingLines.size(); i++) {
+
             // Drawing op
             final Line current = mDrawingLines.get(i);
             final int nextIndex = i+1;
@@ -589,6 +591,7 @@ public class MainActivity extends Activity implements ImageReader.OnImageAvailab
     }
 
     private void stopDrawing() {
+
         Log.d(TAG, "Resetting");
 
         // Clear out the drawing ops queue
@@ -690,9 +693,7 @@ public class MainActivity extends Activity implements ImageReader.OnImageAvailab
         }
 
         infoText(String.format("Drawing %f mm (line %d / %d)", scaledDistance, index, count));
-        Log.d("oscar", String.format("DRAW LINE %s", current.toString()));
 
-        // this function calls MainActivity.this.pivot() when steppers are finished
         mMovementControl.moveStraight(scaledDistance);
     }
 
@@ -707,8 +708,6 @@ public class MainActivity extends Activity implements ImageReader.OnImageAvailab
 
         double degrees = Utilities.calcDegrees(p1, p2, p3);
 
-        // Log.d("fyi", String.format("degrees = %f", degrees));
-
         // skip turn if none required
         if (degrees == 0) {
             return;
@@ -720,7 +719,6 @@ public class MainActivity extends Activity implements ImageReader.OnImageAvailab
 
         infoText(String.format("Turning %f degrees", degrees));
 
-        // this function calls MainActivity.this.drawNextLine() when steppers are finished
         mMovementControl.turn(degrees);
     }
 
@@ -730,7 +728,7 @@ public class MainActivity extends Activity implements ImageReader.OnImageAvailab
         super.onDestroy();
 
         if (mPhysicalInterface != null) {
-            mPhysicalInterface.writeLED(Color.BLACK); // off?
+            mPhysicalInterface.writeLED(Color.BLACK); // off
             mPhysicalInterface.close();
             mPhysicalInterface = null;
         }

--- a/DrawBot/app/src/main/java/com/deeplocal/drawbot/MovementControl.java
+++ b/DrawBot/app/src/main/java/com/deeplocal/drawbot/MovementControl.java
@@ -26,12 +26,9 @@ public class MovementControl {
     private ULN2003 mRightStepper;
     private Servo mPenServo;
 
-    private MainActivity mMainActivity;
     private RobotConfig mRobotConfig;
 
-    public MovementControl(MainActivity mainActivity, RobotConfig robotConfig) {
-
-        mMainActivity = mainActivity;
+    public MovementControl(RobotConfig robotConfig) {
         mRobotConfig = robotConfig;
 
         mLeftStepper = new ULN2003(leftMotorPins[0], leftMotorPins[1], leftMotorPins[2], leftMotorPins[3]);
@@ -51,7 +48,7 @@ public class MovementControl {
     }
 
     // distance in mm
-    public void moveStraight(double distance, boolean isDrawing) {
+    public void moveStraight(double distance) {
 
         int minSpeed = 4000000;
         int maxSpeed = 500000;
@@ -62,14 +59,9 @@ public class MovementControl {
 //        constantMotion(steps, isDrawing, Direction.COUNTERCLOCKWISE, Direction.CLOCKWISE);
         smoothMotion(steps, ULN2003Resolution.HALF, Direction.COUNTERCLOCKWISE, Direction.CLOCKWISE, minSpeed, maxSpeed, rampRate);
 
-//        Log.d(TAG, "Done moving straight");
-
-        if (isDrawing) {
-            mMainActivity.pivot();
-        }
     }
 
-    public void turn(double turnDegrees, boolean isDrawing) {
+    public void turn(double turnDegrees) {
 
         int minSpeed = 4200000;
         int maxSpeed = 400000;
@@ -158,12 +150,6 @@ public class MovementControl {
             Thread.sleep(200);
         } catch (InterruptedException e) {
             Log.e(TAG, "Turn could not sleep", e);
-        }
-
-//        Log.d(TAG, "Done turning");
-
-        if (isDrawing) {
-            mMainActivity.drawNextLine();
         }
     }
 

--- a/DrawBot/app/src/main/java/com/deeplocal/drawbot/MovementControl.java
+++ b/DrawBot/app/src/main/java/com/deeplocal/drawbot/MovementControl.java
@@ -29,6 +29,7 @@ public class MovementControl {
     private RobotConfig mRobotConfig;
 
     public MovementControl(RobotConfig robotConfig) {
+
         mRobotConfig = robotConfig;
 
         mLeftStepper = new ULN2003(leftMotorPins[0], leftMotorPins[1], leftMotorPins[2], leftMotorPins[3]);
@@ -58,7 +59,6 @@ public class MovementControl {
 
 //        constantMotion(steps, isDrawing, Direction.COUNTERCLOCKWISE, Direction.CLOCKWISE);
         smoothMotion(steps, ULN2003Resolution.HALF, Direction.COUNTERCLOCKWISE, Direction.CLOCKWISE, minSpeed, maxSpeed, rampRate);
-
     }
 
     public void turn(double turnDegrees) {

--- a/DrawBot/app/src/main/java/com/deeplocal/drawbot/PhysicalInterface.java
+++ b/DrawBot/app/src/main/java/com/deeplocal/drawbot/PhysicalInterface.java
@@ -43,6 +43,26 @@ public class PhysicalInterface {
         }
     }
 
+    /**
+     * Blocking I/O method to hold the LED on for a specific
+     */
+    public void holdLED(int color, int duration) {
+        writeLED(color);
+        try {
+            Thread.sleep(duration);
+        } catch (InterruptedException e) {
+            Log.e(TAG, "LED could not sleep", e);
+        }
+    }
+
+    /**
+     * Blocking I/O method to blink the LED for a specific duration
+     */
+    public void flashLED(int onColor, int onDuration, int offColor, int offDuration) {
+        holdLED(onColor, onDuration);
+        holdLED(offColor, offDuration);
+    }
+
     public void close() {
 
         Log.d(TAG, "Closing LED interface...");

--- a/DrawBot/app/src/main/java/com/deeplocal/drawbot/PhysicalInterface.java
+++ b/DrawBot/app/src/main/java/com/deeplocal/drawbot/PhysicalInterface.java
@@ -2,8 +2,6 @@ package com.deeplocal.drawbot;
 
 import android.util.Log;
 
-import com.google.android.things.pio.Gpio;
-import com.google.android.things.pio.PeripheralManagerService;
 import com.google.android.things.contrib.driver.apa102.Apa102;
 
 import java.io.IOException;

--- a/DrawBot/app/src/main/java/com/deeplocal/drawbot/Utilities.java
+++ b/DrawBot/app/src/main/java/com/deeplocal/drawbot/Utilities.java
@@ -121,12 +121,12 @@ public class Utilities {
     }
 
     public static void printLineList(String startString, ArrayList<Line> lines, String endString) {
-        Log.d("oscar", startString);
+        Log.d(TAG, startString);
 
         for (int i = 0; i < lines.size(); i++) {
-            Log.d("oscar", String.format("Line %d: %s", i + 1, lines.get(i).toString()));
+            Log.d(TAG, String.format("Line %d: %s", i + 1, lines.get(i).toString()));
         }
-        Log.d("oscar", endString);
+        Log.d(TAG, endString);
     }
 
     public static String toJsonString(ArrayList<Line> lines) {


### PR DESCRIPTION
Rough idea of the threading discussion taking place in [this comment](https://github.com/Deeplocal/android-things-drawbot/commit/8393f3a32f0e6023a4f38945b48489fee879a85c#commitcomment-24474205) with the least amount of changes to the existing code (could be cleaned up more).

The general idea is to abstract all blocking (sleeping) ops into either `MovementControl` or `PhysicalInterface` and then sequence all operations using the background `HandlerThread`. Operations are sequenced as individual operations on the `Handler` rather than a continuous stream of callbacks which represents one synchronous block of code. The current code tries to break the sequence into as many runnable ops as possible. The finer each operation, the easier things are to cancel and reset.

This frees up the main thread to continue handling system events while drawing happens. In addition, it means you can react to button presses during a draw to more easily cancel an operation in progress by simply clearing the queue (simplifying both the stop and reset case).

This code has not been tested at all, and I probably missed a couple cases. It's primarily intended to illustrate the use of the `HandlerThread` as a sequencer for the various operations included in a drawing and how to break those ops up into chunks.